### PR TITLE
feat(guest): implement process_string with ASCII uppercase

### DIFF
--- a/guests/rust/src/lib.rs
+++ b/guests/rust/src/lib.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
 struct Component;
 
 impl Guest for Component {
-    fn process_string(_input: String) -> String {
-        unimplemented!()
+    fn process_string(input: String) -> String {
+        input.to_ascii_uppercase()
     }
 }
 


### PR DESCRIPTION
## 概要
Guest 側 `process_string` が `unimplemented!()` のままで Wasm 実行時に trap していた問題を解消する。`str::to_ascii_uppercase()` を返す本実装に置き換え、ASCII 英小文字は大文字化、非 ASCII バイト（日本語・アクセント付き等）はそのまま保持する。

これにより `cargo run -p host -- "rust wasm"` が `RUST WASM` を返し、Host から Guest までの end-to-end 動作が確認できるようになる。

Closes #6