### PR TITLE
perf(host): load guests via AOT-compiled .cwasm

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 
+[[bin]]
+name = "host"
+path = "src/main.rs"
+
+[[bin]]
+name = "precompile"
+path = "src/bin/precompile.rs"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/host/src/bin/precompile.rs
+++ b/host/src/bin/precompile.rs
@@ -1,0 +1,30 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use wasmtime::{Config, Engine};
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: precompile <input.wasm> <output.cwasm>");
+        std::process::exit(2);
+    }
+    let input = PathBuf::from(&args[1]);
+    let output = PathBuf::from(&args[2]);
+
+    let mut config = Config::new();
+    config.cache_config_load_default()?;
+    let engine = Engine::new(&config)?;
+
+    let wasm = std::fs::read(&input)
+        .with_context(|| format!("failed to read {}", input.display()))?;
+    let serialized = engine.precompile_component(&wasm)?;
+    std::fs::write(&output, &serialized)
+        .with_context(|| format!("failed to write {}", output.display()))?;
+
+    println!(
+        "wrote {} ({} bytes)",
+        output.display(),
+        serialized.len()
+    );
+    Ok(())
+}

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -20,11 +20,11 @@ impl Guest {
         match self {
             Guest::Rust => concat!(
                 env!("CARGO_MANIFEST_DIR"),
-                "/../target/wasm32-wasip2/release/guest_rust.wasm"
+                "/../target/wasm32-wasip2/release/guest_rust.cwasm"
             ),
             Guest::Js => concat!(
                 env!("CARGO_MANIFEST_DIR"),
-                "/../guests/js/dist/guest_js.wasm"
+                "/../guests/js/dist/guest_js.cwasm"
             ),
         }
     }
@@ -58,7 +58,10 @@ fn main() -> Result<()> {
     let mut config = Config::new();
     config.cache_config_load_default()?;
     let engine = Engine::new(&config)?;
-    let component = Component::from_file(&engine, args.guest.component_path())?;
+    // SAFETY: .cwasm はこのプロジェクトの `precompile` バイナリで
+    // 同じ wasmtime バージョン・同じホストで生成したものだけを読み込む前提。
+    let component =
+        unsafe { Component::deserialize_file(&engine, args.guest.component_path())? };
 
     let mut linker: Linker<State> = Linker::new(&engine);
     wasmtime_wasi::add_to_linker_sync(&mut linker)?;


### PR DESCRIPTION
## 概要

ゲスト Wasm のロード経路を AOT コンパイル済み `.cwasm` 経由に切り替え、ホスト起動時のコンパイルコストを削減する。

### 背景

`Component::from_file` ではホスト起動のたびに Wasm をパースし Cranelift で再コンパイルする必要があり、特に JS ゲスト (約 11MB / SpiderMonkey 同梱) ではこのコストが支配的だった。`cache_config_load_default` 経由のディスクキャッシュも効くが、`Component::deserialize_file` で AOT 済みネイティブコードを直接ロードする方が高速。

### 変更内容

- `host/src/bin/precompile.rs` を新設。`Engine::precompile_component` で `.wasm` → `.cwasm` を生成する。
- `host/Cargo.toml` で `host` / `precompile` の 2 つの `[[bin]]` を明示。
- `host/src/main.rs` の component path を `.cwasm` に変更し、`Component::from_file` を `unsafe { Component::deserialize_file(...) }` に置き換え。
  - SAFETY: 同じ wasmtime バージョン・同じホストで生成した `.cwasm` のみを読む前提。

### 計測 (JS ゲスト, `time -p` の `real`)

| | 1 回目 | 2 回目 | 3 回目 |
| --- | --- | --- | --- |
| `from_file` (.wasm, cold cache) | 0.43s | 0.13s | 0.13s |
| `deserialize_file` (.cwasm) | 0.29s | 0.07s | 0.06s |

ウォーム時で約 2 倍速。Rust ゲストはもとより 1ms 未満なので体感差は出ない。

### 使い方

```sh
cargo build -p host --release
./target/release/precompile target/wasm32-wasip2/release/guest_rust.wasm \
    target/wasm32-wasip2/release/guest_rust.cwasm
./target/release/precompile guests/js/dist/guest_js.wasm \
    guests/js/dist/guest_js.cwasm
./target/release/host --guest=js "rust wasm"
```

### 注意点

- `.cwasm` はネイティブコードを含むため Wasm よりサイズが大きい (JS: 11MB → 44MB)。
- wasmtime のバージョンを上げた際は `.cwasm` を再生成する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)